### PR TITLE
fix: make limit parsing more strict (fixes #7)

### DIFF
--- a/lib/limit.js
+++ b/lib/limit.js
@@ -14,12 +14,14 @@ module.exports = function limitParser(input) {
     // convert strings
     if (typeof input === 'string') {
         if (input === 'unlimited') return unlimited;
+        if (!/^\d+$/.test(input)) throw new RequestError('limit must be an integer or "unlimited"');
+        if (isNaN(input)) throw new RequestError('limit must be an integer or "unlimited"');
         input = parseInt(input, 10);
     }
 
     // check type
-    if (typeof input !== 'number' || !Number.isFinite(input)) {
-        throw new RequestError('limit must be a number or "unlimited"');
+    if (typeof input !== 'number' || !Number.isFinite(input) || !Number.isSafeInteger(input)) {
+        throw new RequestError('limit must be an integer or "unlimited"');
     }
 
     // check range

--- a/lib/limit.js
+++ b/lib/limit.js
@@ -15,7 +15,7 @@ module.exports = function limitParser(input) {
     if (typeof input === 'string') {
         if (input === 'unlimited') return unlimited;
         if (!/^\d+$/.test(input)) throw new RequestError('limit must be an integer or "unlimited"');
-        if (isNaN(input)) throw new RequestError('limit must be an integer or "unlimited"');
+        if (Number.isNaN(input)) throw new RequestError('limit must be an integer or "unlimited"');
         input = parseInt(input, 10);
     }
 

--- a/test/limit.spec.js
+++ b/test/limit.spec.js
@@ -27,48 +27,48 @@ describe('limit parser', () => {
     it('should throw an error for non-number strings', () => {
         expect(() => {
             limitParser('foo');
-        }).to.throw(Error);
+        }).to.throw(Error, 'limit must be an integer or "unlimited"');
         expect(() => {
             limitParser({});
-        }).to.throw(Error);
+        }).to.throw(Error, 'limit must be an integer or "unlimited"');
         expect(() => {
             limitParser([]);
-        }).to.throw(Error);
+        }).to.throw(Error, 'limit must be an integer or "unlimited"');
     });
 
-    it('should throw an error for strings that are isNaN, nut might be parsed by parseInt', () => {
+    it('should throw an error for strings that are isNaN, but might be parsed by parseInt', () => {
         expect(() => {
             limitParser('5;1');
-        }).to.throw(Error);
+        }).to.throw(Error, 'limit must be an integer or "unlimited"');
     });
 
     it('should throw an error for non-integers', () => {
         expect(() => {
             limitParser(5.1);
-        }).to.throw(Error);
+        }).to.throw(Error, 'limit must be an integer or "unlimited"');
         expect(() => {
             limitParser('5.1');
-        }).to.throw(Error);
+        }).to.throw(Error, 'limit must be an integer or "unlimited"');
     });
 
     it('should throw an error for unsafe integers', () => {
         expect(() => {
             limitParser('999999999999999999');
-        }).to.throw(Error);
+        }).to.throw(Error, 'limit must be an integer or "unlimited"');
     });
 
     it('should throw an error for numbers < 1', () => {
         expect(() => {
             limitParser(0);
-        }).to.throw(Error);
+        }).to.throw(Error, 'limit must be greater than 0');
         expect(() => {
             limitParser('0');
+        }).to.throw(Error, 'limit must be greater than 0');
+        expect(() => {
+            limitParser(-1, 'limit must be greater than 0');
         }).to.throw(Error);
         expect(() => {
-            limitParser(-1);
-        }).to.throw(Error);
-        expect(() => {
-            limitParser(-100);
+            limitParser(-100, 'limit must be greater than 0');
         }).to.throw(Error);
     });
 });

--- a/test/limit.spec.js
+++ b/test/limit.spec.js
@@ -17,6 +17,7 @@ describe('limit parser', () => {
     it('should accept number strings and convert them', () => {
         expect(limitParser('1')).to.be.a('number');
         expect(limitParser('1234')).to.equal(1234);
+        expect(limitParser('999999999999999')).to.equal(999999999999999);
     });
 
     it('should return null for "unlimited"', () => {
@@ -32,6 +33,27 @@ describe('limit parser', () => {
         }).to.throw(Error);
         expect(() => {
             limitParser([]);
+        }).to.throw(Error);
+    });
+
+    it('should throw an error for strings that are isNaN, nut might be parsed by parseInt', () => {
+        expect(() => {
+            limitParser('5;1');
+        }).to.throw(Error);
+    });
+
+    it('should throw an error for non-integers', () => {
+        expect(() => {
+            limitParser(5.1);
+        }).to.throw(Error);
+        expect(() => {
+            limitParser('5.1');
+        }).to.throw(Error);
+    });
+
+    it('should throw an error for unsafe integers', () => {
+        expect(() => {
+            limitParser('999999999999999999');
         }).to.throw(Error);
     });
 


### PR DESCRIPTION
Throws errors when "limit" is:
- Does not meet `/^\d+$/` (integer number)
- isNaN
- isSafeInteger

This disables "smart" parsing of inputs like `limit=5;foo=bar` (which resulted in `5` before) and other NaN inputs like very large inputs which might cause problems.